### PR TITLE
- change cymunk/cymunk to cymunk.cymunk in ext_modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ else:
     cymunk_files = ['cymunk/cymunk.c']
     cmdclass = {}
 
-ext = Extension('cymunk/cymunk',
+ext = Extension('cymunk.cymunk',
     cymunk_files + c_chipmunk_files,
     include_dirs=c_chipmunk_incs,
     extra_compile_args=[cstdarg, '-ffast-math', '-fPIC', '-DCHIPMUNK_FFI'])


### PR DESCRIPTION
I'm not 100% sure what does it mean, but seems that without this change, I have following error:

```
(kivent2)maho@dlaptop:~/workspace/khamster/pypackages2/cymunk$ python setup.py build_ext --inplace
running build_ext
cythoning cymunk/cymunk.pyx to cymunk/cymunk.c

Error compiling Cython file:
------------------------------------------------------------
...
include "constraint.pxi"
^
------------------------------------------------------------

cymunk/cymunk.pyx:1:0: 'cymunk/cymunk' is not a valid module name
building 'cymunk/cymunk' extension
x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -D_FORTIFY_SOURCE=2 -g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Icymunk/Chipmunk-Physics/include -Icymunk/Chipmunk-Physics/include/chipmunk -I/usr/include/python2.7 -c cymunk/cymunk.c -o build/temp.linux-x86_64-2.7/cymunk/cymunk.o -std=c99 -ffast-math -fPIC -DCHIPMUNK_FFI
cymunk/cymunk.c:1:2: error: #error Do not use this file, it is the result of a failed Cython compilation.
 #error Do not use this file, it is the result of a failed Cython compilation.
  ^
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```
