### PR TITLE
Fixed Vec2d magic methods so they properly work with cython.

### DIFF
--- a/tests/test_vec2d.py
+++ b/tests/test_vec2d.py
@@ -27,6 +27,68 @@ def test_vec2d():
     assert(v.y == 6)
     assert(v[0] == 5)
     assert(v[1] == 6)
+    
+    assert v == (5,6)
+    assert (5,6) == v
+    assert v != (3,6)
+    assert (3,6) != v
+
+
+def test_vec2d_magic_math():
+    import operator
+    params = (
+            (cy.Vec2d(2.1, 7), 3.2),
+            (cy.Vec2d(2.3, 7), (3., 5.7)),
+            (cy.Vec2d(-2.3, 7), cy.Vec2d(0.3, 5.7)),
+        )
+    ops = (
+        operator.add, operator.sub, operator.mul,
+        operator.div, operator.floordiv, operator.truediv,
+        operator.mod,
+        )
+    for left, right in params:
+        tright = right if hasattr(right, '__getitem__') else (right, right)
+        for op in ops:
+            # test op(left, right)
+            msg = "%s( %s , %s )" % (op.__name__, left, right)
+            tres = (op(left.x, tright[0]), op(left.y, tright[1]))
+            res = op(left, right)
+            assert tuple(res) == pytest.approx(tres), msg
+            # test op(right, left)
+            msg = "%s( %s , %s )" % (op.__name__, right, left)
+            tres = (op(tright[0], left.x), op(tright[1], left.y))
+            res = op(right, left)
+            assert tuple(res) == pytest.approx(tres), msg
+
+
+def test_vec2d_magic_math_inplace():
+    import operator
+    params = (
+            (cy.Vec2d(2.1, 7), 3.2),
+            (cy.Vec2d(2.3, 7), (3., 5.7)),
+            (cy.Vec2d(-2.3, 7), cy.Vec2d(0.3, 5.7))
+        )
+    ops = (
+        operator.iadd, operator.isub, operator.imul,
+        operator.idiv, operator.ifloordiv, operator.itruediv,
+        operator.imod
+        )
+    for left, right in params:
+        tright = right if hasattr(right, '__getitem__') else (right, right)
+        for op in ops:
+            left = cy.Vec2d(left)
+            tres = (op(left.x, tright[0]), op(left.y, tright[1]))
+            op(left, right)
+            msg = "%s( %s , %s )" % (op.__name__, left, right)
+            assert tuple(left) == pytest.approx(tres), msg
+
+
+def test_vec2d_magic_unary():
+    import operator
+    assert tuple(operator.neg(cy.Vec2d(-1,1))) == pytest.approx((1,-1))
+    assert tuple(operator.pos(cy.Vec2d(-1,1))) == pytest.approx((-1,1))
+    assert tuple(operator.abs(cy.Vec2d(-1,1))) == pytest.approx((1,1))
+
 
 def test_vec2d_indexerror():
     v = cy.Vec2d(1, 2)


### PR DESCRIPTION
At the moment most of the magic (underscore) functions in the Vec2d class don't work properly (especially with mixed types) as they are in pythons format but cython only supports another (slightly weird) format:
http://cython.readthedocs.io/en/latest/src/userguide/special_methods.html#arithmetic-methods
There are no "right side of operation" functions and eq, lt and so on are moved to a single richcmp method.

This PR updates the Vec2d class to use cythons magic functions for arithmetics and thus fixes #39 

**What this PR does exactly**
- Updated all arithmetic magic functions.
- Implements the  `__richcmp__` to handle == and !=
- Removed the duplicate `rotate` and `rotated` functions.
- Removed all magic functions for bitwise arithmetics (rshift, lshift, and, or, ...) because they only operate on integers and the vec2d class uses floats.
- Removed `__divmod__` because it doesn't really make sense with vectors as far as i am conncerned. We could return two tuples tho.
- Added tests for all magic functions in `tests/test_vec2d.py`. (Some tests for the "real" vector math should maybe added too).



